### PR TITLE
Long format and little fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,9 @@ struct Args {
     /// Scale coverage values by node length
     #[arg(short, long)]
     len_scale: bool,
+    /// Emit graph coverage vector in a single column
+    #[arg(short, long)]
+    coverage_column: bool,
 }
 
 fn main() {
@@ -95,14 +98,23 @@ fn main() {
             l,
             |i, j| { coverage[i-1] += j; },
             |id| { gfa.segments[id-1].sequence.len() }); });
-    print!("#sample");
-    for n in 1..gfa.segments.len()+1 {
-        print!("\tnode.{}", n);
+
+    if (args.coverage_column) {
+        println!("##sample: {}", args.alignments);
+        println!("#coverage");
+        for (i, v) in coverage.into_iter().enumerate() {
+            println!("{}", v as f64 / gfa.segments[i].sequence.len() as f64);
+        }
+    } else {
+        print!("#sample");
+        for n in 1..gfa.segments.len()+1 {
+            print!("\tnode.{}", n);
+        }
+        println!();
+        print!("{}", args.alignments);
+        for (i, v) in coverage.into_iter().enumerate() {
+            print!("\t{}", v as f64 / gfa.segments[i].sequence.len() as f64);
+        }
+        println!();
     }
-    println!();
-    print!("{}", args.alignments);
-    for (i, v) in coverage.into_iter().enumerate() {
-        print!("\t{}", v as f64 / gfa.segments[i].sequence.len() as f64);
-    }
-    println!();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,11 +99,11 @@ fn main() {
             |i, j| { coverage[i-1] += j; },
             |id| { gfa.segments[id-1].sequence.len() }); });
 
-    if (args.coverage_column) {
+    if args.coverage_column {
         println!("##sample: {}", args.alignments);
         println!("#coverage");
         for (i, v) in coverage.into_iter().enumerate() {
-            println!("{}", v as f64 / gfa.segments[i].sequence.len() as f64);
+            println!("{}", if args.len_scale {v as f64  / gfa.segments[i].sequence.len() as f64} else {v as f64});
         }
     } else {
         print!("#sample");
@@ -113,7 +113,7 @@ fn main() {
         println!();
         print!("{}", args.alignments);
         for (i, v) in coverage.into_iter().enumerate() {
-            print!("\t{}", v as f64 / gfa.segments[i].sequence.len() as f64);
+            print!("\t{}", if args.len_scale {v as f64  / gfa.segments[i].sequence.len() as f64} else {v as f64});
         }
         println!();
     }


### PR DESCRIPTION
This PR allows emitting the coverage vector in a single column:

```
gafpack -g graph -a input.gaf -c | head   

##sample: input.gaf
#coverage
891
114
1277
119
3006
10
1094
141
```

Long files are more manageable than large ones.

Furthermore, this PR fixes the usage of the `-l, --len-scale` option that was unused in the code.