### PR TITLE
Node vectors, Edge vectors, and Node+Edge vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,5 @@ authors = ["Erik Garrison <erik.garrison@gmail.com>"]
 [dependencies]
 clap = { version = "4.0.9", features = ["derive"] }
 gfa = "0.10.1"
+log = "0.4.21"
+env_logger = "0.11.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gafpack"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Erik Garrison <erik.garrison@gmail.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gafpack"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Erik Garrison <erik.garrison@gmail.com>"]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use gfa::gfa::GFA;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
 use std::collections::BTreeMap;
+use log::{error};
 
 fn for_each_line_in_file(filename: &str, mut callback: impl FnMut(&str)) {
     let file = File::open(filename).unwrap();
@@ -100,9 +101,17 @@ struct Args {
     coverage_column: bool,
 }
 
-fn main() {   
+fn main() {
+    env_logger::init();
+    
     let args = Args::parse();
     //println!("Hello {}!", args.graph);
+
+    // Check if at least one of node_coverage or edge_coverage is specified
+    if !args.node_coverage && !args.edge_coverage {
+        error!("At least one of --node-coverage or --edge-coverage must be specified.");
+        std::process::exit(1);
+    }
 
     let gfa = {
         let parser = gfa::parser::GFAParser::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use gfa::gfa::GFA;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
+use std::collections::BTreeMap;
 
 fn for_each_line_in_file(filename: &str, mut callback: impl FnMut(&str)) {
     let file = File::open(filename).unwrap();
@@ -11,9 +12,12 @@ fn for_each_line_in_file(filename: &str, mut callback: impl FnMut(&str)) {
     }
 }
 
-fn for_each_step(line: &str,
-                 mut callback: impl FnMut(usize,usize),
-                 mut get_node_len: impl FnMut(usize) -> usize) {
+fn for_each_step(
+    line: &str,
+    mut node_callback: impl FnMut(usize, usize),
+    mut edge_callback: impl FnMut(usize, usize),
+    mut get_node_len: impl FnMut(usize) -> usize,
+) {
     //eprintln!("{}", line);
     let walk = line.split('\t').nth(5).unwrap();
     if walk != "*" {
@@ -23,15 +27,18 @@ fn for_each_step(line: &str,
         let mut target_len = target_end - target_start;
         //eprintln!("target_len = {}", target_len);
         let fields = line.split('\t').nth(5).unwrap()
-            .split(|c| { c == '<' || c == '>' })
-            .filter(|s| { !s.is_empty() })
-            .map(|s| { s.parse::<usize>().unwrap() })
-            .enumerate()
-            .collect::<Vec<(usize,usize)>>();
+            .split(|c| c == '<' || c == '>')
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<&str>>();
+        let orientations = line.split('\t').nth(5).unwrap()
+            .chars()
+            .filter(|c| *c == '<' || *c == '>')
+            .collect::<Vec<char>>();
         let mut seen: usize = 0;
         let fields_len = fields.as_slice().len();
         //eprintln!("fields len = {}", fields_len);
-        for (i, j) in fields {
+        for (i, field) in fields.iter().enumerate() {
+            let j = field.parse::<usize>().unwrap();
             let mut len = get_node_len(j);
             //eprintln!("node {} len = {}", j, len);
             if i == 0 {
@@ -39,7 +46,7 @@ fn for_each_step(line: &str,
                 assert!(len >= target_start);
                 len -= target_start;
             }
-            if i == fields_len-1 {
+            if i == fields_len - 1 {
                 //eprintln!("on last step {} {} {}", len, target_end, seen);
                 if target_len < seen {
                     target_len = seen;
@@ -54,7 +61,15 @@ fn for_each_step(line: &str,
             }
             //eprintln!("node {} adj len = {}", j, len);
             seen += len;
-            callback(j, len);
+            node_callback(j, len);
+            if i < fields_len - 1 {
+                let next_j = fields[i + 1].parse::<usize>().unwrap();
+                if orientations[i] == '>' {
+                    edge_callback(j, next_j);
+                } else {
+                    edge_callback(next_j, j);
+                }
+            }
         }
         //eprintln!("seen = {}", seen);
     }
@@ -71,49 +86,105 @@ struct Args {
     /// Input GAF alignment file
     #[arg(short, long)]
     alignments: String,
-    /// Scale coverage values by node length
+    /// Emit node coverage vector
+    #[arg(short, long)]
+    node_coverage: bool,
+    /// Emit edge coverage vector
+    #[arg(short, long)]
+    edge_coverage: bool,
+    /// Scale node coverage values by node length
     #[arg(short, long)]
     len_scale: bool,
-    /// Emit graph coverage vector in a single column
+    /// Emit coverage vector in a single column
     #[arg(short, long)]
     coverage_column: bool,
 }
 
-fn main() {
+fn main() {   
     let args = Args::parse();
     //println!("Hello {}!", args.graph);
+
     let gfa = {
         let parser = gfa::parser::GFAParser::default();
         let gfa: GFA<usize, ()> = parser.parse_file(&args.graph).unwrap();
         gfa
     };
+
     //println!("{} has {} nodes", args.graph, gfa.segments.len());
-    let mut lines = 0;
-    for_each_line_in_file(&args.alignments, |_l: &str| { lines += 1 });
+    //let mut lines = 0;
+    //for_each_line_in_file(&args.alignments, |_l: &str| { lines += 1 });
     //println!("{} has {} nodes", args.alignments, lines);
-    let mut coverage = vec![0; gfa.segments.len()];
+    
+    let mut node_coverage = vec![0; gfa.segments.len()];
+    
+    let mut edge_coverage: BTreeMap<(usize, usize), usize> = BTreeMap::new();
+    // Initialize edge_coverage with all possible edges in the graph
+    for edge in &gfa.links {
+        edge_coverage.entry((edge.from_segment-1 as usize, edge.to_segment-1 as usize)).or_insert(0);
+    }
+
     for_each_line_in_file(&args.alignments, |l: &str| {
         // get the start pos
         for_each_step(
             l,
-            |i, j| { coverage[i-1] += j; },
-            |id| { gfa.segments[id-1].sequence.len() }); });
+            |i, len| { node_coverage[i-1] += len; },
+            |from, to| {
+                *edge_coverage.entry((from - 1, to - 1)).or_insert(0) += 1;
+            },
+            |id| { gfa.segments[id-1].sequence.len() });
+        });
 
     if args.coverage_column {
         println!("##sample: {}", args.alignments);
-        println!("#coverage");
-        for (i, v) in coverage.into_iter().enumerate() {
-            println!("{}", if args.len_scale {v as f64  / gfa.segments[i].sequence.len() as f64} else {v as f64});
+        
+        let mut header = String::from("#coverage");
+        let mut header_parts = Vec::new();
+        if args.node_coverage {
+            header_parts.push(format!("num.nodes: {}", gfa.segments.len()));
+        }
+        if args.edge_coverage {
+            header_parts.push(format!("num.edges: {}", edge_coverage.len()));
+        }
+        if !header_parts.is_empty() {
+            header.push_str(&format!(" ({})", header_parts.join(", ")));
+        }
+        println!("{}", header);
+        
+        if args.node_coverage {
+            for (i, v) in node_coverage.into_iter().enumerate() {
+                println!("{}", if args.len_scale {v as f64  / gfa.segments[i].sequence.len() as f64} else {v as f64});
+            }
+        }
+        
+        if args.edge_coverage {
+            for ((_, _), v) in edge_coverage.iter() {
+                //println!("{} -> {}: {}", from + 1, to + 1, v);
+                println!("{}", v);
+            }
         }
     } else {
         print!("#sample");
-        for n in 1..gfa.segments.len()+1 {
-            print!("\tnode.{}", n);
+        if args.node_coverage {
+            for n in 1..=gfa.segments.len() {
+                print!("\tnode.{}", n);
+            }
+        }
+        if args.edge_coverage {
+            for ((from, to), _) in edge_coverage.iter() {
+                print!("\tedge.{}.{}", from + 1, to + 1);
+            }
         }
         println!();
         print!("{}", args.alignments);
-        for (i, v) in coverage.into_iter().enumerate() {
-            print!("\t{}", if args.len_scale {v as f64  / gfa.segments[i].sequence.len() as f64} else {v as f64});
+        if args.node_coverage {
+            for (i, v) in node_coverage.into_iter().enumerate() {
+                print!("\t{}", if args.len_scale {v as f64  / gfa.segments[i].sequence.len() as f64} else {v as f64});
+            }
+        }
+        if args.edge_coverage {
+            for ((_, _), v) in edge_coverage.iter() {
+                print!("\t{}", v);
+            }
         }
         println!();
     }


### PR DESCRIPTION
Node coverage vector, row
```
gafpack --graph x.gfa --alignments x.gaf -n | cut -f 1-5 | column -t
#sample  node.1  node.2  node.3  node.4
x.gaf    72      36      2       236

gafpack --graph x.gfa --alignments x.gaf -n | head -n 1 | awk -F'\t' '{print NF}' 
20817
```
Edge coverage vector, row
```
gafpack --graph x.gfa --alignments x.gaf -e | cut -f 1-5 | column -t
#sample  edge.1.2  edge.2.3  edge.2.4  edge.3.4
x.gaf    4         1         3         2

gafpack --graph x.gfa --alignments x.gaf -e | head -n 1 | awk -F'\t' '{print NF}' 
26619
```
Node+Edge coverage vector, column
```
gafpack --graph x.gfa --alignments x.gaf -ne | head -n 1 | awk -F'\t' '{print NF}' 
47435
```

Node coverage vector, column
```
gafpack --graph x.gfa --alignments x.gaf -n -c | head -n 5 | column -t 
##sample:  x.gaf        
#coverage  (num.nodes:  20816)
72                      
36                      
2                       

gafpack --graph x.gfa --alignments x.gaf -n -c | wc -l                 
20818
```
Edge coverage vector, column
```
gafpack --graph x.gfa --alignments x.gaf -e -c | head -n 5 | column -t
##sample:  x.gaf        
#coverage  (num.edges:  26618)
4                       
1                       
3                       

gafpack --graph x.gfa --alignments x.gaf -e -c | wc -l
26620
```
Node+Edge coverage vector, column
```
gafpack --graph x.gfa --alignments x.gaf -ne -c | head -n 5 | column -t
##sample:  x.gaf                            
#coverage  (num.nodes:  20816,  num.edges:  26618)
72                                          
36                                          
2  

gafpack --graph x.gfa --alignments x.gaf -ne -c | wc -l
47436
```