### PR TITLE
Weight evidence based on query range occurrence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 *~
+.aider*
+.env

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ gafpack -g graph.gfa -a alignments.gaf >coverage.tsv
 - `-a, --alignments`: Input GAF alignment file (required) 
 - `-l, --len-scale`: Scale coverage values by node length
 - `-c, --coverage-column`: Output coverage vector in single column format
+- `-w, --weight-queries`: Weight coverage by query group occurrences
 
 ### Output Formats
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn main() {
     //let mut lines = 0;
     //for_each_line_in_file(&args.alignments, |_l: &str| { lines += 1 });
     //println!("{} has {} nodes", args.alignments, lines);
-    let mut coverage = vec![0; gfa.segments.len()];
+    let mut coverage : Vec<f64> = vec![0.0; gfa.segments.len()];
     
     if args.weight_queries {
         // First pass: count query occurrences
@@ -133,7 +133,7 @@ fn main() {
             
             for_each_step(
                 l,
-                |i, j| { coverage[i-1] += (j as f64 / *count as f64) as usize; },
+                |i, j| { coverage[i-1] += j as f64 / *count as f64; },
                 |id| { gfa.segments[id-1].sequence.len()
             });
         });
@@ -142,7 +142,7 @@ fn main() {
         for_each_line_in_file(&args.alignments, |l: &str| {
             for_each_step(
                 l,
-                |i, j| { coverage[i-1] += j; },
+                |i, j| { coverage[i-1] += j as f64; },
                 |id| { gfa.segments[id-1].sequence.len()
             });
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use gfa::gfa::GFA;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
+use std::collections::HashMap;
 
 /// Iterates through each line in a file, applying the provided callback function
 /// 
@@ -108,12 +109,26 @@ fn main() {
     //let mut lines = 0;
     //for_each_line_in_file(&args.alignments, |_l: &str| { lines += 1 });
     //println!("{} has {} nodes", args.alignments, lines);
+    // First pass: count query occurrences
+    let mut query_counts: HashMap<String, usize> = HashMap::new();
+    for_each_line_in_file(&args.alignments, |l: &str| {
+        let fields: Vec<&str> = l.split('\t').collect();
+        if fields.len() >= 4 {
+            let query_key = format!("{}:{}:{}", fields[0], fields[2], fields[3]);
+            *query_counts.entry(query_key).or_insert(0) += 1;
+        }
+    });
+
+    // Second pass: calculate coverage with query count adjustment
     let mut coverage = vec![0; gfa.segments.len()];
     for_each_line_in_file(&args.alignments, |l: &str| {
-        // get the start pos
+        let fields: Vec<&str> = l.split('\t').collect();
+        let query_key = format!("{}:{}:{}", fields[0], fields[2], fields[3]);
+        let count = query_counts.get(&query_key).unwrap_or(&1);
+        
         for_each_step(
             l,
-            |i, j| { coverage[i-1] += j; },
+            |i, j| { coverage[i-1] += (j as f64 / *count as f64) as usize; },
             |id| { gfa.segments[id-1].sequence.len()
         });
     });


### PR DESCRIPTION
If a query range is repeated multiple times (for example, for multimapping reads), we increment the corresponding node coverages by `1/occurrences` instead of `1`.